### PR TITLE
Add library path to PluginTest::TestArgs

### DIFF
--- a/src/tests/plugin.rs
+++ b/src/tests/plugin.rs
@@ -1,6 +1,7 @@
 //! Tests for individual plugin instances.
 
 use clap::ValueEnum;
+use std::path::Path;
 use std::process::Command;
 
 use super::{TestCase, TestResult};
@@ -48,9 +49,9 @@ pub enum PluginTestCase {
 }
 
 impl<'a> TestCase<'a> for PluginTestCase {
-    /// A loaded CLAP plugin library and the ID of the plugin contained within that library that
-    /// should be tested.
-    type TestArgs = (&'a PluginLibrary, &'a str);
+    /// Path to a CLAP plugin library, a loaded CLAP plugin library and the ID of the plugin contained
+    /// within that library that should be tested.
+    type TestArgs = (&'a Path, &'a PluginLibrary, &'a str);
 
     fn description(&self) -> String {
         match self {
@@ -128,7 +129,7 @@ impl<'a> TestCase<'a> for PluginTestCase {
         }
     }
 
-    fn set_out_of_process_args(&self, command: &mut Command, (library, plugin_id): Self::TestArgs) {
+    fn set_out_of_process_args(&self, command: &mut Command, (path, _library, plugin_id): Self::TestArgs) {
         let test_name = self.to_string();
 
         command
@@ -138,12 +139,12 @@ impl<'a> TestCase<'a> for PluginTestCase {
                     .unwrap()
                     .get_name(),
             )
-            .arg(library.library_path())
+            .arg(path)
             .arg(plugin_id)
             .arg(test_name);
     }
 
-    fn run_in_process(&self, (library, plugin_id): Self::TestArgs) -> TestResult {
+    fn run_in_process(&self, (_, library, plugin_id): Self::TestArgs) -> TestResult {
         let status = match self {
             PluginTestCase::DescriptorConsistency => {
                 descriptor::test_consistency(library, plugin_id)

--- a/src/tests/plugin.rs
+++ b/src/tests/plugin.rs
@@ -144,7 +144,7 @@ impl<'a> TestCase<'a> for PluginTestCase {
             .arg(test_name);
     }
 
-    fn run_in_process(&self, (_, library, plugin_id): Self::TestArgs) -> TestResult {
+    fn run_in_process(&self, (_path, library, plugin_id): Self::TestArgs) -> TestResult {
         let status = match self {
             PluginTestCase::DescriptorConsistency => {
                 descriptor::test_consistency(library, plugin_id)

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -215,7 +215,7 @@ pub fn validate(verbosity: Verbosity, settings: &ValidatorSettings) -> Result<Va
                                         &test,
                                         verbosity,
                                         settings,
-                                        (&plugin_library, &plugin_metadata.id),
+                                        (&library_path, &plugin_library, &plugin_metadata.id),
                                     )
                                 })
                                 .collect::<Result<Vec<TestResult>>>()?,
@@ -296,7 +296,7 @@ pub fn validate(verbosity: Verbosity, settings: &ValidatorSettings) -> Result<Va
                                         &test,
                                         verbosity,
                                         settings,
-                                        (&plugin_library, &plugin_metadata.id),
+                                        (&library_path, &plugin_library, &plugin_metadata.id),
                                     )
                                 })
                                 .collect::<Result<Vec<TestResult>>>()?,
@@ -365,7 +365,7 @@ pub fn run_single_test(settings: &SingleTestSettings) -> Result<()> {
                 .parse::<PluginTestCase>()
                 .with_context(|| format!("Unknown test name: {}", &settings.name))?;
 
-            test_case.run_in_process((&plugin_library, &settings.plugin_id))
+            test_case.run_in_process((&settings.path, &plugin_library, &settings.plugin_id))
         }
     };
 


### PR DESCRIPTION
Fixes running tests out of process on Mac OS