### PR TITLE
fix state transition bug in PluginAudioThread's Drop implementation

### DIFF
--- a/src/plugin/instance/audio_thread.rs
+++ b/src/plugin/instance/audio_thread.rs
@@ -44,14 +44,10 @@ pub enum ProcessStatus {
 
 impl Drop for PluginAudioThread<'_> {
     fn drop(&mut self) {
-        match self
-            .state()
-            .status
-            .compare_exchange(PluginStatus::Processing, PluginStatus::Activated)
-        {
-            Ok(_) => self.stop_processing(),
-            Err(PluginStatus::Activated) => (),
-            Err(state) => panic!(
+        match self.status() {
+            PluginStatus::Processing => self.stop_processing(),
+            PluginStatus::Activated => (),
+            state => panic!(
                 "The plugin was in an invalid state '{state:?}' when the audio thread got \
                  dropped, this is a clap-validator bug"
             ),


### PR DESCRIPTION
# before
1. `compare_exchange` switches state from Processing to Activated
2. Drop calls [`stop_processing`](https://github.com/free-audio/clap-validator/blob/2f71690639a742ce805574ce42e31250e3147aa9/src/plugin/instance/audio_thread.rs#L153), which contains the following assertion which will fail:
```
assert_plugin_state_eq!(self, PluginStatus::Processing);
```

# after
IIUC this now has the intended behavior, which is:
* If Processing, then call `stop_processing` (which transitions to Activated)
* If Activated, do nothing
* Otherwise, panic