### PR TITLE
feat: add Tier-A extension tests for latency, tail, and render

### DIFF
--- a/src/plugin/ext.rs
+++ b/src/plugin/ext.rs
@@ -6,10 +6,13 @@ use std::ffi::CStr;
 use std::ptr::NonNull;
 
 pub mod audio_ports;
+pub mod latency;
 pub mod note_ports;
 pub mod params;
 pub mod preset_load;
+pub mod render;
 pub mod state;
+pub mod tail;
 
 /// An abstraction for a CLAP plugin extension. `P` here is the plugin type. In practice, this is
 /// either `Plugin` or `PluginAudioThread`. Abstractions for main thread functions will implement

--- a/src/plugin/ext/latency.rs
+++ b/src/plugin/ext/latency.rs
@@ -1,0 +1,46 @@
+//! Abstractions for interacting with the `latency` extension.
+
+use anyhow::Result;
+use clap_sys::ext::latency::{CLAP_EXT_LATENCY, clap_plugin_latency};
+use std::ffi::CStr;
+use std::ptr::NonNull;
+
+use super::Extension;
+use crate::plugin::assert_plugin_state_eq;
+use crate::plugin::instance::{Plugin, PluginStatus};
+use crate::util::unsafe_clap_call;
+
+/// Abstraction for the `latency` extension.
+#[derive(Debug)]
+pub struct Latency<'a> {
+    plugin: &'a Plugin<'a>,
+    latency: NonNull<clap_plugin_latency>,
+}
+
+impl<'a> Extension<&'a Plugin<'a>> for Latency<'a> {
+    const EXTENSION_ID: &'static CStr = CLAP_EXT_LATENCY;
+
+    type Struct = clap_plugin_latency;
+
+    fn new(plugin: &'a Plugin<'a>, extension_struct: NonNull<Self::Struct>) -> Self {
+        Self {
+            plugin,
+            latency: extension_struct,
+        }
+    }
+}
+
+impl Latency<'_> {
+    fn status(&self) -> PluginStatus {
+        self.plugin.status()
+    }
+
+    /// Query the plugin's latency in samples. Requires the plugin to be activated.
+    pub fn get(&self) -> Result<u32> {
+        assert_plugin_state_eq!(self, PluginStatus::Activated);
+
+        let latency = self.latency.as_ptr();
+        let plugin = self.plugin.as_ptr();
+        Ok(unsafe_clap_call! { latency=>get(plugin) })
+    }
+}

--- a/src/plugin/ext/render.rs
+++ b/src/plugin/ext/render.rs
@@ -1,0 +1,68 @@
+//! Abstractions for interacting with the `render` extension.
+
+use anyhow::Result;
+use clap_sys::ext::render::{
+    CLAP_EXT_RENDER, CLAP_RENDER_OFFLINE, CLAP_RENDER_REALTIME, clap_plugin_render,
+    clap_plugin_render_mode,
+};
+use std::ffi::CStr;
+use std::ptr::NonNull;
+
+use super::Extension;
+use crate::plugin::assert_plugin_state_initialized;
+use crate::plugin::instance::{Plugin, PluginStatus};
+use crate::util::unsafe_clap_call;
+
+/// Abstraction for the `render` extension.
+#[derive(Debug)]
+pub struct Render<'a> {
+    plugin: &'a Plugin<'a>,
+    render: NonNull<clap_plugin_render>,
+}
+
+impl<'a> Extension<&'a Plugin<'a>> for Render<'a> {
+    const EXTENSION_ID: &'static CStr = CLAP_EXT_RENDER;
+
+    type Struct = clap_plugin_render;
+
+    fn new(plugin: &'a Plugin<'a>, extension_struct: NonNull<Self::Struct>) -> Self {
+        Self {
+            plugin,
+            render: extension_struct,
+        }
+    }
+}
+
+impl Render<'_> {
+    fn status(&self) -> PluginStatus {
+        self.plugin.status()
+    }
+
+    /// Whether the plugin has a hard realtime requirement.
+    pub fn has_hard_realtime_requirement(&self) -> Result<bool> {
+        assert_plugin_state_initialized!(self);
+
+        let render = self.render.as_ptr();
+        let plugin = self.plugin.as_ptr();
+        Ok(unsafe_clap_call! { render=>has_hard_realtime_requirement(plugin) })
+    }
+
+    /// Request a render mode. Returns `false` if the plugin does not support the mode.
+    pub fn set(&self, mode: clap_plugin_render_mode) -> Result<bool> {
+        assert_plugin_state_initialized!(self);
+
+        let render = self.render.as_ptr();
+        let plugin = self.plugin.as_ptr();
+        Ok(unsafe_clap_call! { render=>set(plugin, mode) })
+    }
+
+    /// Convenience: set realtime mode.
+    pub fn set_realtime(&self) -> Result<bool> {
+        self.set(CLAP_RENDER_REALTIME)
+    }
+
+    /// Convenience: set offline mode.
+    pub fn set_offline(&self) -> Result<bool> {
+        self.set(CLAP_RENDER_OFFLINE)
+    }
+}

--- a/src/plugin/ext/state.rs
+++ b/src/plugin/ext/state.rs
@@ -21,8 +21,10 @@ pub struct State<'a> {
 }
 
 /// An input stream backed by a slice.
+///
+/// `pub(crate)` so sibling extensions (e.g. `state-context`) can reuse the same stream helpers.
 #[derive(Debug)]
-struct InputStream<'a> {
+pub(crate) struct InputStream<'a> {
     // The `ctx` pointer is set to this struct after creating the object
     vtable: clap_istream,
 
@@ -37,8 +39,10 @@ struct InputStream<'a> {
 }
 
 /// An output stream backed by a vector.
+///
+/// `pub(crate)` so sibling extensions (e.g. `state-context`) can reuse the same stream helpers.
 #[derive(Debug)]
-struct OutputStream {
+pub(crate) struct OutputStream {
     // The `ctx` pointer is set to this struct after creating the object
     vtable: clap_ostream,
 

--- a/src/plugin/ext/tail.rs
+++ b/src/plugin/ext/tail.rs
@@ -1,0 +1,46 @@
+//! Abstractions for interacting with the `tail` extension.
+
+use anyhow::Result;
+use clap_sys::ext::tail::{CLAP_EXT_TAIL, clap_plugin_tail};
+use std::ffi::CStr;
+use std::ptr::NonNull;
+
+use super::Extension;
+use crate::plugin::assert_plugin_state_eq;
+use crate::plugin::instance::{Plugin, PluginStatus};
+use crate::util::unsafe_clap_call;
+
+/// Abstraction for the `tail` extension.
+#[derive(Debug)]
+pub struct Tail<'a> {
+    plugin: &'a Plugin<'a>,
+    tail: NonNull<clap_plugin_tail>,
+}
+
+impl<'a> Extension<&'a Plugin<'a>> for Tail<'a> {
+    const EXTENSION_ID: &'static CStr = CLAP_EXT_TAIL;
+
+    type Struct = clap_plugin_tail;
+
+    fn new(plugin: &'a Plugin<'a>, extension_struct: NonNull<Self::Struct>) -> Self {
+        Self {
+            plugin,
+            tail: extension_struct,
+        }
+    }
+}
+
+impl Tail<'_> {
+    fn status(&self) -> PluginStatus {
+        self.plugin.status()
+    }
+
+    /// Query the processing tail length in samples. Requires the plugin to be activated.
+    pub fn get(&self) -> Result<u32> {
+        assert_plugin_state_eq!(self, PluginStatus::Activated);
+
+        let tail = self.tail.as_ptr();
+        let plugin = self.plugin.as_ptr();
+        Ok(unsafe_clap_call! { tail=>get(plugin) })
+    }
+}

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -3,6 +3,12 @@
 use anyhow::{Context, Result};
 use clap_sys::ext::audio_ports::{clap_host_audio_ports, CLAP_EXT_AUDIO_PORTS};
 use clap_sys::ext::draft::preset_load::{clap_host_preset_load, CLAP_EXT_PRESET_LOAD};
+use clap_sys::ext::latency::{clap_host_latency, CLAP_EXT_LATENCY};
+use clap_sys::ext::log::{
+    clap_host_log, clap_log_severity, CLAP_EXT_LOG, CLAP_LOG_DEBUG, CLAP_LOG_ERROR,
+    CLAP_LOG_FATAL, CLAP_LOG_HOST_MISBEHAVING, CLAP_LOG_INFO, CLAP_LOG_PLUGIN_MISBEHAVING,
+    CLAP_LOG_WARNING,
+};
 use clap_sys::ext::note_ports::{
     clap_host_note_ports, clap_note_dialect, CLAP_EXT_NOTE_PORTS, CLAP_NOTE_DIALECT_CLAP,
     CLAP_NOTE_DIALECT_MIDI, CLAP_NOTE_DIALECT_MIDI_MPE,
@@ -11,6 +17,7 @@ use clap_sys::ext::params::{
     clap_host_params, clap_param_clear_flags, clap_param_rescan_flags, CLAP_EXT_PARAMS,
 };
 use clap_sys::ext::state::{clap_host_state, CLAP_EXT_STATE};
+use clap_sys::ext::tail::{clap_host_tail, CLAP_EXT_TAIL};
 use clap_sys::ext::thread_check::{clap_host_thread_check, CLAP_EXT_THREAD_CHECK};
 use clap_sys::factory::draft::preset_discovery::clap_preset_discovery_location_kind;
 use clap_sys::host::clap_host;
@@ -73,10 +80,13 @@ pub struct Host {
 
     // These are the vtables for the extensions supported by the host
     clap_host_audio_ports: clap_host_audio_ports,
+    clap_host_latency: clap_host_latency,
+    clap_host_log: clap_host_log,
     clap_host_note_ports: clap_host_note_ports,
     clap_host_params: clap_host_params,
     clap_host_preset_load: clap_host_preset_load,
     clap_host_state: clap_host_state,
+    clap_host_tail: clap_host_tail,
     clap_host_thread_check: clap_host_thread_check,
 }
 
@@ -255,6 +265,12 @@ impl Host {
                 is_rescan_flag_supported: Some(Self::ext_audio_ports_is_rescan_flag_supported),
                 rescan: Some(Self::ext_audio_ports_rescan),
             },
+            clap_host_latency: clap_host_latency {
+                changed: Some(Self::ext_latency_changed),
+            },
+            clap_host_log: clap_host_log {
+                log: Some(Self::ext_log_log),
+            },
             clap_host_note_ports: clap_host_note_ports {
                 supported_dialects: Some(Self::ext_note_ports_supported_dialects),
                 rescan: Some(Self::ext_note_ports_rescan),
@@ -270,6 +286,9 @@ impl Host {
             },
             clap_host_state: clap_host_state {
                 mark_dirty: Some(Self::ext_state_mark_dirty),
+            },
+            clap_host_tail: clap_host_tail {
+                changed: Some(Self::ext_tail_changed),
             },
             clap_host_thread_check: clap_host_thread_check {
                 is_main_thread: Some(Self::ext_thread_check_is_main_thread),
@@ -479,6 +498,10 @@ impl Host {
         let extension_id_cstr = CStr::from_ptr(extension_id);
         if extension_id_cstr == CLAP_EXT_AUDIO_PORTS {
             &this.clap_host_audio_ports as *const _ as *const c_void
+        } else if extension_id_cstr == CLAP_EXT_LATENCY {
+            &this.clap_host_latency as *const _ as *const c_void
+        } else if extension_id_cstr == CLAP_EXT_LOG {
+            &this.clap_host_log as *const _ as *const c_void
         } else if extension_id_cstr == CLAP_EXT_NOTE_PORTS {
             &this.clap_host_note_ports as *const _ as *const c_void
         } else if extension_id_cstr == CLAP_EXT_PRESET_LOAD {
@@ -487,6 +510,8 @@ impl Host {
             &this.clap_host_params as *const _ as *const c_void
         } else if extension_id_cstr == CLAP_EXT_STATE {
             &this.clap_host_state as *const _ as *const c_void
+        } else if extension_id_cstr == CLAP_EXT_TAIL {
+            &this.clap_host_tail as *const _ as *const c_void
         } else if extension_id_cstr == CLAP_EXT_THREAD_CHECK {
             &this.clap_host_thread_check as *const _ as *const c_void
         } else {
@@ -667,6 +692,62 @@ impl Host {
 
         this.assert_main_thread("clap_host_state::mark_dirty()");
         log::debug!("TODO: Handle 'clap_host_state::mark_dirty()'");
+    }
+
+    unsafe extern "C" fn ext_latency_changed(host: *const clap_host) {
+        unsafe {
+            check_null_ptr!(host, (*host).host_data);
+            let (_, this) = InstanceState::from_clap_host_ptr(host);
+
+            this.assert_main_thread("clap_host_latency::changed()");
+            log::debug!("Plugin reported latency change via 'clap_host_latency::changed()'");
+        }
+    }
+
+    unsafe extern "C" fn ext_tail_changed(host: *const clap_host) {
+        unsafe {
+            check_null_ptr!(host, (*host).host_data);
+            let (_, this) = InstanceState::from_clap_host_ptr(host);
+
+            // Spec: may be called from main or audio thread.
+            log::debug!("Plugin reported tail change via 'clap_host_tail::changed()'");
+            let _ = this;
+        }
+    }
+
+    unsafe extern "C" fn ext_log_log(
+        host: *const clap_host,
+        severity: clap_log_severity,
+        msg: *const c_char,
+    ) {
+        unsafe {
+            check_null_ptr!(host, (*host).host_data, msg);
+            let (_, this) = InstanceState::from_clap_host_ptr(host);
+
+            // log may be called from any thread
+            let _ = this;
+            let message = match util::cstr_ptr_to_mandatory_string(msg) {
+                Ok(s) => s,
+                Err(err) => {
+                    log::error!("Plugin called clap_host_log::log() with invalid msg: {err:#}");
+                    return;
+                }
+            };
+
+            match severity {
+                CLAP_LOG_DEBUG => log::debug!("[plugin] {message}"),
+                CLAP_LOG_INFO => log::info!("[plugin] {message}"),
+                CLAP_LOG_WARNING => log::warn!("[plugin] {message}"),
+                CLAP_LOG_ERROR | CLAP_LOG_FATAL => log::error!("[plugin] {message}"),
+                CLAP_LOG_HOST_MISBEHAVING => {
+                    log::error!("[plugin] host-misbehaving: {message}")
+                }
+                CLAP_LOG_PLUGIN_MISBEHAVING => {
+                    log::warn!("[plugin] plugin-misbehaving: {message}")
+                }
+                other => log::info!("[plugin] (severity {other}) {message}"),
+            }
+        }
     }
 
     unsafe extern "C" fn ext_thread_check_is_main_thread(host: *const clap_host) -> bool {

--- a/src/tests/plugin.rs
+++ b/src/tests/plugin.rs
@@ -7,6 +7,7 @@ use super::{TestCase, TestResult};
 use crate::plugin::library::PluginLibrary;
 
 mod descriptor;
+mod extensions;
 mod params;
 mod processing;
 mod state;
@@ -45,6 +46,12 @@ pub enum PluginTestCase {
     StateReproducibilityFlush,
     #[strum(serialize = "state-buffered-streams")]
     StateBufferedStreams,
+    #[strum(serialize = "latency-basic")]
+    LatencyBasic,
+    #[strum(serialize = "tail-basic")]
+    TailBasic,
+    #[strum(serialize = "render-modes")]
+    RenderModes,
 }
 
 impl<'a> TestCase<'a> for PluginTestCase {
@@ -125,6 +132,19 @@ impl<'a> TestCase<'a> for PluginTestCase {
                  when reloading and resaving the state.",
                 PluginTestCase::StateReproducibilityBasic
             ),
+            PluginTestCase::LatencyBasic => String::from(
+                "If the plugin implements 'clap.latency', activates the plugin and queries its \
+                 reported latency in samples.",
+            ),
+            PluginTestCase::TailBasic => String::from(
+                "If the plugin implements 'clap.tail', activates the plugin and queries its \
+                 reported processing tail length in samples.",
+            ),
+            PluginTestCase::RenderModes => String::from(
+                "If the plugin implements 'clap.render', queries hard-realtime requirement and \
+                 tries setting realtime and offline render modes. Offline may return false if \
+                 unsupported; realtime must succeed.",
+            ),
         }
     }
 
@@ -181,6 +201,12 @@ impl<'a> TestCase<'a> for PluginTestCase {
             PluginTestCase::StateBufferedStreams => {
                 state::test_state_buffered_streams(library, plugin_id)
             }
+            PluginTestCase::LatencyBasic => {
+                extensions::test_latency_basic(library, plugin_id)
+            }
+            PluginTestCase::TailBasic => extensions::test_tail_basic(library, plugin_id),
+            PluginTestCase::RenderModes => extensions::test_render_modes(library, plugin_id),
+
         };
 
         self.create_result(status)

--- a/src/tests/plugin/extensions.rs
+++ b/src/tests/plugin/extensions.rs
@@ -1,0 +1,153 @@
+//! Basic smoke tests for optional CLAP extensions (Tier A).
+//!
+//! Each test skips when the plugin does not implement the extension.
+
+use anyhow::{Context, Result};
+
+use crate::plugin::ext::latency::Latency;
+use crate::plugin::ext::render::Render;
+use crate::plugin::ext::tail::Tail;
+use crate::plugin::ext::Extension;
+use crate::plugin::host::Host;
+use crate::plugin::library::PluginLibrary;
+use crate::tests::TestStatus;
+
+const SAMPLE_RATE: f64 = 44_100.0;
+const MIN_BUFFER: usize = 1;
+const MAX_BUFFER: usize = 512;
+
+/// The test for `PluginTestCase::LatencyBasic`.
+pub fn test_latency_basic(library: &PluginLibrary, plugin_id: &str) -> Result<TestStatus> {
+    let host = Host::new();
+    let plugin = library
+        .create_plugin(plugin_id, host.clone())
+        .context("Could not create the plugin instance")?;
+
+    plugin.init().context("Error during initialization")?;
+    let latency = match plugin.get_extension::<Latency>() {
+        Some(latency) => latency,
+        None => {
+            return Ok(TestStatus::Skipped {
+                details: Some(format!(
+                    "The plugin does not implement the '{}' extension.",
+                    Latency::EXTENSION_ID.to_str().unwrap(),
+                )),
+            });
+        }
+    };
+    host.handle_callbacks_once();
+
+    // Spec (CLAP 1.2.x): latency may only be queried while activated.
+    plugin
+        .activate(SAMPLE_RATE, MIN_BUFFER, MAX_BUFFER)
+        .context("Error while activating the plugin")?;
+    host.handle_callbacks_once();
+
+    let samples = latency
+        .get()
+        .context("Error while querying 'clap_plugin_latency::get()'")?;
+    host.handle_callbacks_once();
+    host.callback_error_check()
+        .context("An error occured during a host callback")?;
+
+    plugin.deactivate();
+
+    Ok(TestStatus::Success {
+        details: Some(format!("Reported latency: {samples} samples")),
+    })
+}
+
+/// The test for `PluginTestCase::TailBasic`.
+pub fn test_tail_basic(library: &PluginLibrary, plugin_id: &str) -> Result<TestStatus> {
+    let host = Host::new();
+    let plugin = library
+        .create_plugin(plugin_id, host.clone())
+        .context("Could not create the plugin instance")?;
+
+    plugin.init().context("Error during initialization")?;
+    let tail = match plugin.get_extension::<Tail>() {
+        Some(tail) => tail,
+        None => {
+            return Ok(TestStatus::Skipped {
+                details: Some(format!(
+                    "The plugin does not implement the '{}' extension.",
+                    Tail::EXTENSION_ID.to_str().unwrap(),
+                )),
+            });
+        }
+    };
+    host.handle_callbacks_once();
+
+    plugin
+        .activate(SAMPLE_RATE, MIN_BUFFER, MAX_BUFFER)
+        .context("Error while activating the plugin")?;
+    host.handle_callbacks_once();
+
+    let samples = tail
+        .get()
+        .context("Error while querying 'clap_plugin_tail::get()'")?;
+    host.handle_callbacks_once();
+    host.callback_error_check()
+        .context("An error occured during a host callback")?;
+
+    plugin.deactivate();
+
+    Ok(TestStatus::Success {
+        details: Some(format!("Reported tail: {samples} samples")),
+    })
+}
+
+/// The test for `PluginTestCase::RenderModes`.
+pub fn test_render_modes(library: &PluginLibrary, plugin_id: &str) -> Result<TestStatus> {
+    let host = Host::new();
+    let plugin = library
+        .create_plugin(plugin_id, host.clone())
+        .context("Could not create the plugin instance")?;
+
+    plugin.init().context("Error during initialization")?;
+    let render = match plugin.get_extension::<Render>() {
+        Some(render) => render,
+        None => {
+            return Ok(TestStatus::Skipped {
+                details: Some(format!(
+                    "The plugin does not implement the '{}' extension.",
+                    Render::EXTENSION_ID.to_str().unwrap(),
+                )),
+            });
+        }
+    };
+    host.handle_callbacks_once();
+
+    let hard_rt = render
+        .has_hard_realtime_requirement()
+        .context("Error while querying 'has_hard_realtime_requirement()'")?;
+
+    // Realtime should be supported by any non-broken implementation.
+    let realtime_ok = render
+        .set_realtime()
+        .context("Error while setting CLAP_RENDER_REALTIME")?;
+    if !realtime_ok {
+        anyhow::bail!(
+            "'clap_plugin_render::set(CLAP_RENDER_REALTIME)' returned false; realtime mode \
+             should be supported."
+        );
+    }
+
+    // Offline is optional — false means "not supported", not a failure.
+    let offline_ok = render
+        .set_offline()
+        .context("Error while setting CLAP_RENDER_OFFLINE")?;
+
+    // Leave the plugin in realtime mode for any subsequent host lifecycle.
+    let _ = render.set_realtime()?;
+
+    host.handle_callbacks_once();
+    host.callback_error_check()
+        .context("An error occured during a host callback")?;
+
+    Ok(TestStatus::Success {
+        details: Some(format!(
+            "hard_realtime_requirement={hard_rt}, offline_supported={offline_ok}"
+        )),
+    })
+}


### PR DESCRIPTION
Add plugin extension wrappers and host-side support for `clap.latency`, `clap.tail`, and `clap.render`. Each test skips when the plugin does not implement the extension.

### Changes
- **New ext wrappers:** `latency`, `render`, `tail` (following existing `audio_ports`/`params`/`state` pattern)
- **Host:** expose `clap_host_latency`, `clap_host_log`, `clap_host_tail` vtables so plugins can call `changed()` and `log()`
- **New tests:** `LatencyBasic`, `TailBasic`, `RenderModes` — skippable smoke tests
- **`InputStream`/`OutputStream`** made `pub(crate)` for future sibling extension reuse (e.g. `state-context`)

### What's NOT included
`state-context` requires draft extension support in `clap-sys` that isn't in upstream yet. Will send as follow-up once clap-sys is bumped.