### PR TITLE
test: add DAW-typical lifecycle and state reproducibility tests

### DIFF
--- a/src/tests/plugin.rs
+++ b/src/tests/plugin.rs
@@ -29,6 +29,8 @@ pub enum PluginTestCase {
     ProcessNoteOutOfPlaceBasic,
     #[strum(serialize = "process-note-inconsistent")]
     ProcessNoteInconsistent,
+    #[strum(serialize = "lifecycle-reactivate")]
+    LifecycleReactivate,
     #[strum(serialize = "param-conversions")]
     ParamConversions,
     #[strum(serialize = "param-fuzz-basic")]
@@ -43,6 +45,8 @@ pub enum PluginTestCase {
     StateReproducibilityNullCookies,
     #[strum(serialize = "state-reproducibility-flush")]
     StateReproducibilityFlush,
+    #[strum(serialize = "state-reproducibility-process-after-load")]
+    StateReproducibilityProcessAfterLoad,
     #[strum(serialize = "state-buffered-streams")]
     StateBufferedStreams,
 }
@@ -78,6 +82,11 @@ impl<'a> TestCase<'a> for PluginTestCase {
                 "Sends intentionally inconsistent and mismatching note and MIDI events to the \
                  plugin with its default parameter values and tests the output for consistency. \
                  Uses out-of-place audio processing.",
+            ),
+            PluginTestCase::LifecycleReactivate => String::from(
+                "Activates the plugin, processes a few buffers, deactivates it, then reactivates \
+                 and processes again. Catches crashes and state leaks during the reactivation \
+                 cycle that DAWs perform on buffer-size or sample-rate changes.",
             ),
             PluginTestCase::ParamConversions => String::from(
                 "Asserts that value to string and string to value conversions are supported for \
@@ -118,6 +127,12 @@ impl<'a> TestCase<'a> for PluginTestCase {
                  asserts that the two states are identical. The parameter values are set updated \
                  using the process function to create the first state, and using the flush \
                  function to create the second state.",
+            ),
+            PluginTestCase::StateReproducibilityProcessAfterLoad => String::from(
+                "Randomizes a plugin's parameters, processes audio, saves the state, recreates \
+                 the plugin instance, reloads the state, processes audio again, and then \
+                 asserts that re-saving the state produces the same result. Catches state \
+                 corruption that only manifests during audio processing after a state restore.",
             ),
             PluginTestCase::StateBufferedStreams => format!(
                 "Performs the same state and parameter reproducibility check as in '{}', but this \
@@ -163,6 +178,9 @@ impl<'a> TestCase<'a> for PluginTestCase {
             PluginTestCase::ProcessNoteInconsistent => {
                 processing::test_process_note_inconsistent(library, plugin_id)
             }
+            PluginTestCase::LifecycleReactivate => {
+                processing::test_lifecycle_reactivate(library, plugin_id)
+            }
             PluginTestCase::ParamConversions => params::test_param_conversions(library, plugin_id),
             PluginTestCase::ParamFuzzBasic => params::test_param_fuzz_basic(library, plugin_id),
             PluginTestCase::ParamSetWrongNamespace => {
@@ -177,6 +195,9 @@ impl<'a> TestCase<'a> for PluginTestCase {
             }
             PluginTestCase::StateReproducibilityFlush => {
                 state::test_state_reproducibility_flush(library, plugin_id)
+            }
+            PluginTestCase::StateReproducibilityProcessAfterLoad => {
+                state::test_state_reproducibility_process_after_load(library, plugin_id)
             }
             PluginTestCase::StateBufferedStreams => {
                 state::test_state_buffered_streams(library, plugin_id)

--- a/src/tests/plugin/processing.rs
+++ b/src/tests/plugin/processing.rs
@@ -452,3 +452,75 @@ fn check_out_of_place_output_consistency(
 
     Ok(())
 }
+
+/// DAW-typical lifecycle test: create → init → activate → process → deactivate →
+/// activate → process → deactivate → destroy.
+/// Catches crashes during reactivation and state leaks between cycles.
+pub fn test_lifecycle_reactivate(
+    library: &PluginLibrary,
+    plugin_id: &str,
+) -> Result<TestStatus> {
+    let mut prng = new_prng();
+
+    let host = Host::new();
+    let plugin = library
+        .create_plugin(plugin_id, host.clone())
+        .context("Could not create the plugin instance")?;
+    plugin.init().context("Error during initialization")?;
+
+    let audio_ports_config = match plugin.get_extension::<AudioPorts>() {
+        Some(audio_ports) => audio_ports
+            .config()
+            .context("Error while querying 'audio-ports' IO configuration")?,
+        None => {
+            return Ok(TestStatus::Skipped {
+                details: Some(format!(
+                    "The plugin does not implement the '{}' extension.",
+                    AudioPorts::EXTENSION_ID.to_str().unwrap(),
+                )),
+            });
+        }
+    };
+    host.handle_callbacks_once();
+
+    let (mut input_buffers, mut output_buffers) = audio_ports_config.create_buffers(512);
+
+    // First cycle: activate → process → deactivate
+    {
+        let mut pt = ProcessingTest::new_out_of_place(
+            &plugin,
+            &mut input_buffers,
+            &mut output_buffers,
+        )?;
+        pt.run(
+            3,
+            ProcessConfig::default(),
+            |process_data| {
+                process_data.buffers.randomize(&mut prng);
+                Ok(())
+            },
+        )?;
+    }
+
+    // Second cycle: reactivate → process → deactivate
+    // DAWs do this on buffer-size changes, sample-rate changes, etc.
+    {
+        let mut pt = ProcessingTest::new_out_of_place(
+            &plugin,
+            &mut input_buffers,
+            &mut output_buffers,
+        )?;
+        pt.run(
+            3,
+            ProcessConfig::default(),
+            |process_data| {
+                process_data.buffers.randomize(&mut prng);
+                Ok(())
+            },
+        )?;
+    }
+
+    host.callback_error_check()
+        .context("An error occurred during a host callback")?;
+    Ok(TestStatus::Success { details: None })
+}

--- a/src/tests/plugin/state.rs
+++ b/src/tests/plugin/state.rs
@@ -643,3 +643,166 @@ fn format_mismatching_values(
         .collect::<Vec<String>>()
         .join(", ")
 }
+
+/// DAW-typical state round-trip: create → init → process → save → destroy →
+/// recreate → load → process → save → compare.
+/// Catches state corruption that only manifests during audio processing after
+/// a state restore (e.g. uninitialized buffers, stale pointers).
+pub fn test_state_reproducibility_process_after_load(
+    library: &PluginLibrary,
+    plugin_id: &str,
+) -> Result<TestStatus> {
+    let mut prng = new_prng();
+
+    let host = Host::new();
+    let plugin = library
+        .create_plugin(plugin_id, host.clone())
+        .context("Could not create the plugin instance")?;
+
+    let (expected_state, expected_param_values) = {
+        plugin.init().context("Error during initialization")?;
+
+        let audio_ports_config = match plugin.get_extension::<AudioPorts>() {
+            Some(audio_ports) => audio_ports
+                .config()
+                .context("Error while querying 'audio-ports' IO configuration")?,
+            None => AudioPortConfig::default(),
+        };
+        let params = match plugin.get_extension::<Params>() {
+            Some(params) => params,
+            None => {
+                return Ok(TestStatus::Skipped {
+                    details: Some(format!(
+                        "The plugin does not implement the '{}' extension.",
+                        Params::EXTENSION_ID.to_str().unwrap(),
+                    )),
+                });
+            }
+        };
+        let state = match plugin.get_extension::<State>() {
+            Some(state) => state,
+            None => {
+                return Ok(TestStatus::Skipped {
+                    details: Some(format!(
+                        "The plugin does not implement the '{}' extension.",
+                        State::EXTENSION_ID.to_str().unwrap(),
+                    )),
+                });
+            }
+        };
+        host.handle_callbacks_once();
+
+        let param_infos = params
+            .info()
+            .context("Failure while fetching the plugin's parameters")?;
+        let param_fuzzer = ParamFuzzer::new(&param_infos);
+        let random_param_set_events: Vec<_> =
+            param_fuzzer.randomize_params_at(&mut prng, 0).collect();
+
+        let (mut input_buffers, mut output_buffers) = audio_ports_config.create_buffers(512);
+        ProcessingTest::new_out_of_place(&plugin, &mut input_buffers, &mut output_buffers)?
+            .run_once(ProcessConfig::default(), move |process_data| {
+                *process_data.input_events.events.lock() = random_param_set_events;
+                Ok(())
+            })?;
+
+        let expected_param_values: BTreeMap<clap_id, f64> = param_infos
+            .keys()
+            .map(|param_id| params.get(*param_id).map(|value| (*param_id, value)))
+            .collect::<Result<BTreeMap<clap_id, f64>>>()?;
+
+        let expected_state = state.save()?;
+        host.handle_callbacks_once();
+
+        (expected_state, expected_param_values)
+    };
+
+    drop(plugin);
+
+    // Second instance: load state, then process, then save again
+    let plugin = library
+        .create_plugin(plugin_id, host.clone())
+        .context("Could not create the plugin instance a second time")?;
+    plugin
+        .init()
+        .context("Error while initializing the second plugin instance")?;
+
+    let params = match plugin.get_extension::<Params>() {
+        Some(params) => params,
+        None => {
+            return Ok(TestStatus::Skipped {
+                details: Some(format!(
+                    "The plugin does not implement the '{}' extension.",
+                    Params::EXTENSION_ID.to_str().unwrap(),
+                )),
+            });
+        }
+    };
+    let state = match plugin.get_extension::<State>() {
+        Some(state) => state,
+        None => {
+            return Ok(TestStatus::Skipped {
+                details: Some(format!(
+                    "The plugin's second instance does not implement the '{}' extension.",
+                    State::EXTENSION_ID.to_str().unwrap()
+                )),
+            });
+        }
+    };
+    host.handle_callbacks_once();
+
+    state.load(&expected_state)?;
+    host.handle_callbacks_once();
+
+    // Verify params match after load
+    let actual_param_values: BTreeMap<clap_id, f64> = expected_param_values
+        .keys()
+        .map(|param_id| params.get(*param_id).map(|value| (*param_id, value)))
+        .collect::<Result<BTreeMap<clap_id, f64>>>()?;
+    if actual_param_values != expected_param_values {
+        let param_infos = params
+            .info()
+            .context("Failure while fetching the plugin's parameters")?;
+        anyhow::bail!(
+            "After reloading the state, the plugin's parameter values do not match. \
+             Mismatching values are {}.",
+            format_mismatching_values(actual_param_values, &expected_param_values, &param_infos)
+        );
+    }
+
+    // Process AFTER load — this is the DAW-typical sequence
+    let audio_ports_config = match plugin.get_extension::<AudioPorts>() {
+        Some(audio_ports) => audio_ports
+            .config()
+            .context("Error while querying 'audio-ports' IO configuration")?,
+        None => AudioPortConfig::default(),
+    };
+    let (mut input_buffers, mut output_buffers) = audio_ports_config.create_buffers(512);
+    ProcessingTest::new_out_of_place(&plugin, &mut input_buffers, &mut output_buffers)?
+        .run_once(ProcessConfig::default(), |_process_data| Ok(()))?;
+
+    // Save again and compare
+    let actual_state = state.save()?;
+    host.handle_callbacks_once();
+
+    host.callback_error_check()
+        .context("An error occurred during a host callback")?;
+    if actual_state == expected_state {
+        Ok(TestStatus::Success { details: None })
+    } else {
+        let (expected_state_file_path, mut expected_state_file) =
+            PluginTestCase::StateReproducibilityBasic.temporary_file(plugin_id, EXPECTED_STATE_FILE_NAME)?;
+        let (actual_state_file_path, mut actual_state_file) =
+            PluginTestCase::StateReproducibilityBasic.temporary_file(plugin_id, ACTUAL_STATE_FILE_NAME)?;
+
+        expected_state_file.write_all(&expected_state)?;
+        actual_state_file.write_all(&actual_state)?;
+
+        anyhow::bail!(
+            "Re-saving the loaded state after processing resulted in a different state file. \
+             Expected: '{}'. Actual: '{}'.",
+            expected_state_file_path.display(),
+            actual_state_file_path.display(),
+        )
+    }
+}


### PR DESCRIPTION
Two new tests that catch real-world DAW issues:

### `lifecycle-reactivate`
Cycles through activate → process → deactivate → reactivate → process.

Catches crashes during plugin reactivation, which happens in DAWs when the user changes buffer size or sample rate while the plugin is loaded. Several CLAP plugins silently crash here because their `activate()` doesn't properly reinitialize DSP state.

### `state-reproducibility-process-after-load`
State round-trip with audio processing after state load, then compares state before and after.

Catches state corruption that only manifests during audio processing — e.g. a plugin that correctly saves/loads parameter values but whose internal DSP state drifts in a way that changes the next save output.