### PR TITLE
chore: fix clippy warnings (dead_code, unused_variable)

### DIFF
--- a/src/plugin/ext/params.rs
+++ b/src/plugin/ext/params.rs
@@ -348,6 +348,7 @@ impl Params<'_> {
     }
 }
 
+#[allow(dead_code)]
 impl Param {
     /// Whether the parameter is hidden and should be ignored.
     pub fn hidden(&self) -> bool {

--- a/src/tests/plugin_library/scanning.rs
+++ b/src/tests/plugin_library/scanning.rs
@@ -91,7 +91,7 @@ pub fn test_scan_rtld_now(library_path: &Path) -> Result<TestStatus> {
 }
 
 #[cfg(not(unix))]
-pub fn test_scan_rtld_now(library_path: &Path) -> Result<TestStatus> {
+pub fn test_scan_rtld_now(_library_path: &Path) -> Result<TestStatus> {
     Ok(TestStatus::Skipped {
         details: Some(String::from(
             "This test is only relevant to Unix-like platforms",


### PR DESCRIPTION
Two minor clippy fixes:

- `#[allow(dead_code)]` on `impl Param` — `hidden()` only called in tests
- Prefix unused `library_path` parameter with underscore in non-Unix `test_scan_rtld_now` stub